### PR TITLE
Use heap_mem variable for JVM args in nomad plan

### DIFF
--- a/ermintrude.nomad
+++ b/ermintrude.nomad
@@ -28,7 +28,7 @@ job "ermintrude" {
 
         args = [
           "java",
-          "-Xmx2048m",
+          "-Xmx{{PUBLISHING_RESOURCE_HEAP_MEM}}m",
           "-Drestolino.files=target/web",
           "-Drestolino.packageprefix=com.github.onsdigital.ermintrude.api",
           "-jar target/*-jar-with-dependencies.jar",


### PR DESCRIPTION
### What

Use new heap_mem variable for JVM args in nomad plan to prevent app requesting too much memory

### How to review

Check correct vars being used

### Who can review

Anyone