### PR TITLE
Improve nomad plan and allow for being able to split nomad classes

### DIFF
--- a/ermintrude.nomad
+++ b/ermintrude.nomad
@@ -7,6 +7,7 @@ job "ermintrude" {
     min_healthy_time = "30s"
     healthy_deadline = "2m"
     max_parallel     = 1
+    auto_revert      = true
     stagger          = "150s"
   }
 

--- a/ermintrude.nomad
+++ b/ermintrude.nomad
@@ -16,7 +16,8 @@ job "ermintrude" {
 
     constraint {
       attribute = "${node.class}"
-      value     = "publishing"
+      operator  = "regexp"
+      value     = "publishing.*"
     }
 
     task "ermintrude" {

--- a/ermintrude.nomad
+++ b/ermintrude.nomad
@@ -28,6 +28,8 @@ job "ermintrude" {
 
         args = [
           "java",
+          "-server",
+          "-Xms{{PUBLISHING_RESOURCE_HEAP_MEM}}m",
           "-Xmx{{PUBLISHING_RESOURCE_HEAP_MEM}}m",
           "-Drestolino.files=target/web",
           "-Drestolino.packageprefix=com.github.onsdigital.ermintrude.api",

--- a/ermintrude.nomad
+++ b/ermintrude.nomad
@@ -4,8 +4,10 @@ job "ermintrude" {
   type        = "service"
 
   update {
-    stagger      = "90s"
-    max_parallel = 1
+    min_healthy_time = "30s"
+    healthy_deadline = "2m"
+    max_parallel     = 1
+    stagger          = "150s"
   }
 
   group "publishing" {


### PR DESCRIPTION
### What

* Set the min heap size in nomad plan so we will fail fast if we are out of memory and to reduce wasted time resizing the heap
* Configure the healthy threshold and deadline
* Enable auto rollback on failed deploy
* Increase the stagger time to allow enough time for scheduling
* Allow for splitting the nomad classes

### How to review

Ensure configurations are valid and logical.

### Who can review

Anyone but me.
