### PR TITLE
Release 1.1.1: New prod nomad plans

### DIFF
--- a/ermintrude.nomad
+++ b/ermintrude.nomad
@@ -7,6 +7,7 @@ job "ermintrude" {
     min_healthy_time = "30s"
     healthy_deadline = "2m"
     max_parallel     = 1
+    auto_revert      = true
     stagger          = "150s"
   }
 

--- a/ermintrude.nomad
+++ b/ermintrude.nomad
@@ -16,7 +16,8 @@ job "ermintrude" {
 
     constraint {
       attribute = "${node.class}"
-      value     = "publishing"
+      operator  = "regexp"
+      value     = "publishing.*"
     }
 
     task "ermintrude" {

--- a/ermintrude.nomad
+++ b/ermintrude.nomad
@@ -28,6 +28,8 @@ job "ermintrude" {
 
         args = [
           "java",
+          "-server",
+          "-Xms{{PUBLISHING_RESOURCE_HEAP_MEM}}m",
           "-Xmx{{PUBLISHING_RESOURCE_HEAP_MEM}}m",
           "-Drestolino.files=target/web",
           "-Drestolino.packageprefix=com.github.onsdigital.ermintrude.api",

--- a/ermintrude.nomad
+++ b/ermintrude.nomad
@@ -4,8 +4,10 @@ job "ermintrude" {
   type        = "service"
 
   update {
-    stagger      = "90s"
-    max_parallel = 1
+    min_healthy_time = "30s"
+    healthy_deadline = "2m"
+    max_parallel     = 1
+    stagger          = "150s"
   }
 
   group "publishing" {

--- a/ermintrude.nomad
+++ b/ermintrude.nomad
@@ -20,6 +20,13 @@ job "ermintrude" {
       value     = "publishing.*"
     }
 
+    restart {
+      attempts = 3
+      delay    = "15s"
+      interval = "1m"
+      mode     = "delay"
+    }
+
     task "ermintrude" {
       driver = "docker"
 


### PR DESCRIPTION
### What

In this release:
* Update the nomad plan for deployment to new production:
  * Set a min heap size to avoid wasted time resizing the heap
  * Allow splitting of the nomad classes so apps that do not require the content volume can float
  * Enable auto rollback of failed deployements
  * Add the restart stanza to support nomad 0.8+

### How to review

Check that the correct commits have been included in this commit and that no details are missing under 'In this release'.

### Who can review

Anyone but me.
